### PR TITLE
Don't define `latestPng` to the return from `getPngStream()`

### DIFF
--- a/parrot-ar-drone-controller.js
+++ b/parrot-ar-drone-controller.js
@@ -130,7 +130,6 @@ mqtt.connect(function(client, deviceId) {
      }, length);
    } else if(msg.d.action === '#takepicture') {
     console.log('take a picture');
-    pngStream = drone.getPngStream();
     if(!latestPng) {
       console.log('No images yet');
       var options = {
@@ -152,7 +151,6 @@ mqtt.connect(function(client, deviceId) {
         }
       };
       request.post({uri: msg.d.callback, formData: formData}, function(err, httpResponse, body) {
-        latestPng = drone.getPngStream();
         if(err) {
           console.log("error posting picture " + err);
         } else {


### PR DESCRIPTION
latestPng was being redefined to the return from `getPngStream()` which is the stream itself. if we didn't receive new data between when this happens and when we receive the next `#takepicture` command, the code attempted to send the stream object via form data which resulted in the app crashing.

i also removed redefining the stream every time we receive the `#takepicture` command - only need to open it in the beginning of the app.
